### PR TITLE
Further meson.build changes

### DIFF
--- a/man/meson.build
+++ b/man/meson.build
@@ -1,4 +1,19 @@
 # Manual page build file
 
-# Manual page
-install_man('qman.1')
+pandoc = find_program('pandoc', required: get_option('man-pages'))
+if pandoc.found()
+  output = 'qman.1'
+  manpage = configure_file(
+    input: ['qman.1.md'],
+    output: output,
+    command: [
+      pandoc,
+      '-s',
+      '-t', 'man',
+      '@INPUT@',
+      '-o', '@OUTPUT@'
+    ]
+  )
+
+  install_man(manpage)
+endif

--- a/man/meson.build
+++ b/man/meson.build
@@ -1,11 +1,4 @@
 # Manual page build file
 
 # Manual page
-custom_target('manpage',
-  input: 'qman.1',
-  output: 'qman.1',
-  command: ['cp', '@INPUT@', '@OUTPUT@'],
-  install: true,
-  install_dir: 'man/man1',
-  install_tag: 'doc'
-)
+install_man('qman.1')

--- a/man/meson.build
+++ b/man/meson.build
@@ -7,5 +7,5 @@ custom_target('manpage',
   command: ['cp', '@INPUT@', '@OUTPUT@'],
   install: true,
   install_dir: 'man/man1',
-  install_tag: 'docs'
+  install_tag: 'doc'
 )

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ custom_target('readme_md',
   command: ['cp', '@INPUT@', '@OUTPUT@'],
   install: true,
   install_dir: 'share/doc/qman',
-  install_tag: 'docs'
+  install_tag: 'doc'
 )
 
 # TESTING.md
@@ -26,5 +26,5 @@ custom_target('testing_md',
   command: ['cp', '@INPUT@', '@OUTPUT@'],
   install: true,
   install_dir: 'share/doc/qman',
-  install_tag: 'docs'
+  install_tag: 'doc'
 )

--- a/meson.build
+++ b/meson.build
@@ -10,8 +10,10 @@ subdir('src')
 subdir('man')
 
 # Documentation files
-install_data(
-  ['README.md', 'TESTING.md'],
-  install_dir: get_option('docdir'),
-  install_tag: 'doc'
-)
+if get_option('docs').allowed()
+  install_data(
+    ['README.md', 'TESTING.md'],
+    install_dir: get_option('docdir'),
+    install_tag: 'doc'
+  )
+endif

--- a/meson.build
+++ b/meson.build
@@ -9,22 +9,9 @@ project('qman', 'c',
 subdir('src')
 subdir('man')
 
-# README.md
-custom_target('readme_md',
-  input: 'README.md',
-  output: 'README.md',
-  command: ['cp', '@INPUT@', '@OUTPUT@'],
-  install: true,
-  install_dir: 'share/doc/qman',
-  install_tag: 'doc'
-)
-
-# TESTING.md
-custom_target('testing_md',
-  input: 'TESTING.md',
-  output: 'TESTING.md',
-  command: ['cp', '@INPUT@', '@OUTPUT@'],
-  install: true,
-  install_dir: 'share/doc/qman',
+# Documentation files
+install_data(
+  ['README.md', 'TESTING.md'],
+  install_dir: get_option('docdir'),
   install_tag: 'doc'
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,17 @@
 option('docdir',
-  type : 'string',
-  value : 'share/doc/qman',
+  type: 'string',
+  value: 'share/doc/qman',
   description : 'directory for documentation files'
+)
+
+option('man-pages',
+  type: 'feature',
+  value: 'auto',
+  description: 'install manpage'
+)
+
+option('docs',
+  type: 'feature',
+  value: 'auto',
+  description: 'install extra documentation'
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,5 @@
+option('docdir',
+  type : 'string',
+  value : 'share/doc/qman',
+  description : 'directory for documentation files'
+)


### PR DESCRIPTION
Hi again, sorry for the delayed response.

The path used for the documentation raised QA warnings on Portage. I've updated the build files to query built-in paths for the different components.

It seems to be conventional to use `docdir` as a meson_option, and might eventually [become a built-in feature](https://github.com/mesonbuild/meson/issues/825). For now, the default path remains unchanged, but is specified in `meson_options.txt` instead. With this, it becomes easy to modify it during meson configuration: `-Ddocdir="/usr/share/doc/${PF}"`

The last commit might be a bit more controversial, as it adds to the complexity of the build files, but allows for more accurate ebuild files. We might want to combine `man-pages` and `docs` into a single feature. In practice, both of these names are used, and it's also common to combine them into either of them. I kept them separate as you had a preference for `man/` over `docs/`.

A nit: I've renamed the tags from `docs` to `doc`, since it's suggested to be used by meson's documentation.

As it stands, my ebuild boils down to the following, plus dependency metadata:
```bash
src_configure() {
	local emesonargs=(
		$(meson_feature man man-pages)
		$(meson_feature doc docs)
		-Ddocdir="/usr/share/doc/${PF}"
	)
	meson_src_configure
}
```

Also, I would happily push to `::guru` as soon as there is a tagged release :)