### PR TITLE
replace unsafe function

### DIFF
--- a/src/program.c
+++ b/src/program.c
@@ -375,13 +375,18 @@ bool section_header_level(line_t *line) {
 // Helper of man_toc(). Massage text member of every entry in toc (of size
 // toc_len) with the groff command, in order to remove escaped characters, etc.
 void tocgroff(toc_entry_t *toc, unsigned toc_len) {
-  char *tpath;               // temporary file path
+  char tpath[TPATH_MAX_LEN]; // temporary file path
   char cmdstr[BS_LINE] = ""; // groff 'massage' command
   char texts[BS_LINE];       // 8-bit version of current toc text
   unsigned i;                // iterator
 
+
   // Prepare tpath and cmdstr
-  tpath = tempnam(NULL, "qman");
+  char *tmpdir = getenv("TMPDIR");
+  if (!tmpdir) {
+    tmpdir = "/tmp";
+  }
+  snprintf(tpath, sizeof(tpath), "%s/qmanXXXXXX", tmpdir);
   snprintf(cmdstr, BS_LINE, "%s -man -rLL=1024m -Tutf8 %s 2>>/dev/null",
            config.misc.groff_path, tpath);
 
@@ -421,21 +426,25 @@ void tocgroff(toc_entry_t *toc, unsigned toc_len) {
   //   logprintf("%d: type=%d text=%ls", i, toc[i].type, toc[i].text);
 
   // Tidy up and restore the environment
+  free(tmpdir);
   unlink(tpath);
-  free(tpath);
 }
 
 // Helper of man_sections(). Massage every entry in sections (of size
 // sections_len) with the groff command, in order to remove escaped characters,
 // etc.
 void secgroff(wchar_t **sections, unsigned sections_len) {
-  char *tpath;               // temporary file path
+  char tpath[TPATH_MAX_LEN]; // temporary file path
   char cmdstr[BS_LINE] = ""; // groff 'massage' command
   char texts[BS_LINE];       // 8-bit version of current toc text
   unsigned i;                // iterator
 
   // Prepare tpath and cmdstr
-  tpath = tempnam(NULL, "qman");
+  char *tmpdir = getenv("TMPDIR");
+  if (!tmpdir) {
+    tmpdir = "/tmp";
+  }
+  snprintf(tpath, sizeof(tpath), "%s/qmanXXXXXX", tmpdir);
   snprintf(cmdstr, BS_LINE, "%s -man -rLL=1024m -Tutf8 %s 2>>/dev/null",
            config.misc.groff_path, tpath);
 
@@ -470,8 +479,8 @@ void secgroff(wchar_t **sections, unsigned sections_len) {
   xpclose(pp);
 
   // Tidy up and restore the environment
+  free(tmpdir);
   unlink(tpath);
-  free(tpath);
 }
 
 //

--- a/src/util.h
+++ b/src/util.h
@@ -40,6 +40,7 @@ typedef struct {
 // Buffer sizes
 #define BS_SHORT 128 // length of a short array
 #define BS_LINE 1024 // length of an array that is suitable for a line of text
+#define TPATH_MAX_LEN 512 // max length of a temporary path (must account for appearance in BS_LINE cutoff in commands)
 
 // Rudimentary logging, used for debugging
 #define F_LOG "./qman.log" // log file


### PR DESCRIPTION
As I was building from source on Gentoo, I was getting warnings from my compiler about using `tempnam()`. I've addressed this here.

I doubt tpath will ever exceed 256 characters, although I would have usually preferred to use `PATH_MAX` from `<linux/limits.h>`. I set it to a much lower static value instead since the `cmdstr` following it could truncate it if the groff path is too large.

From manpage:
> Never use this function.  Use mkstemp(3) or tmpfile(3) instead.