### PR TITLE
Use git tags for versioning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@
 # Project declaration
 project('qman', 'c',
   license: 'BSD-2-Clause',
-  version: '1.2.1'
+  version: run_command('git', 'describe', '--tags', '--abbrev', check: true).stdout().strip()
 )
 
 # Executable


### PR DESCRIPTION
As I was checking out the ebuild for the live ebuild (aka pulling directly from HEAD), I realized the version in the meson version still reflected the statically built version. I've changed it to use the tags from git here instead to avoid manually having to change it.

For tagged releases, it'll just reflect the name of the tag (i.e `v1.2.1`). For non-tagged ones, it will prefix the hash with the most recent tag + count of commits since then (i.e `v1.2.1-4-gfdb53a2`).

To drop a new release, it's a matter of `git tag --sign v1.2.2 -m "Release v1.2.2" && git push --tags`, it shouldn't require an explicit commit, I believe. If you want a commit anyway, you could `git commit --allow-empty -m "Release v.1.2.2"` prior to tagging it.