### PR TITLE
fall back to find_library()

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,7 @@
 # Executable build file
 
+cc = meson.get_compiler('c')
+
 # Configuration subsystem sources (generated from config_def.py using cog)
 cog = find_program('cogapp', 'cog')
 cog_cmd = [cog, '-d', '-o', '@OUTPUT@', '@INPUT@']
@@ -31,8 +33,13 @@ deps = [
   dependency('zlib')
 ]
 if get_option('bzip2').enabled() or get_option('bzip2').auto()
+  bz2 = dependency('bzip2', required : false)
+  if not bz2.found()
+    bz2 = cc.find_library('bz2', required : true)
+  endif
+
+  deps += [bz2]
   add_global_arguments('-DQMAN_BZIP2=true', language : 'c')
-  deps += [dependency('bzip2')]
 endif
 executable('qman',
   sources: src,


### PR DESCRIPTION
On Gentoo, `dependency('bzip2')` fails as there is no `bzip2.pc` file available for pkgconfig to find. While ideally this should be fixed (and it seems to be on upstream/HEAD of bzip2), the latest stable release of bzip2 does not offer pkgconfig support.

Until that's a stable feature, I suggest we just fall back to `compiler.find_library()`.

Related: #14 


cc @mgorny: I saw you were the maintainer for `app-alternatives/bzip2`. Does this mean you're also the maintainer for bzip2, or does this fall back on base-system?

This might be an awkward place to ask for this, but I'm not exactly sure where I would ask otherwise: I was wondering if we could patch in [bzip2.pc.in](https://gitlab.com/bzip2/bzip2/-/blob/master/bzip2.pc.in) onto 1.0.8.