### PR TITLE
Fix building qman on Tumbleweed

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -83,3 +83,10 @@ different operating systems and distros:
 >
 > For Ubuntu 20.04, you must substitute `meson compile` with `ninja` during the
 > build process
+
+## openSUSE Tumbleweed
+
+```
+  # zypper refresh
+  # zypper install gcc cmake meson ninja python3-cogapp ncurses-devel libinih-devel cmake zlib-devel libbz2-devel
+```

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,7 +4,7 @@
 cc = meson.get_compiler('c')
 
 # Configuration subsystem sources (generated from config_def.py using cog)
-cog = find_program('cogapp', 'cog')
+cog = find_program('cogapp', 'cog', 'cog.py')
 cog_cmd = [cog, '-d', '-o', '@OUTPUT@', '@INPUT@']
 config_h = custom_target('config.h',
   input: 'config.h.cog',

--- a/src/tui.c
+++ b/src/tui.c
@@ -411,7 +411,7 @@ void draw_toc(toc_entry_t *toc, unsigned toc_len, unsigned top,
 
 void init_tui() {
   // Initialize and set up ncurses
-  ESCDELAY = config.tcap.escdelay;
+  set_escdelay(config.tcap.escdelay);
   initscr();
   raw();
   keypad(stdscr, true);


### PR DESCRIPTION
This makes the necessary adjustments for qman to build on Tumbleweed. Hopefully this means it can get packaged without trouble now.