### PR TITLE
Fix sigusr1_handler function signature

### DIFF
--- a/src/tui.c
+++ b/src/tui.c
@@ -160,7 +160,7 @@ void sigusr1_reset() {
 
 // Re-configure the program. `init_tui()` makes sure this is called whenever
 // `SIGUSR1` is received.
-void sigusr1_handler() {
+void sigusr1_handler(int signum) {
   // Don't attempt attempt to reconfigure on ancient terminals
   if (tcap.colours < 256 || tcap.term == strstr(tcap.term, "rxvt")) {
     return;


### PR DESCRIPTION
When building qman on Fedora Linux using the flags used by the project for packaging*, the following error occurs:

```console
$ gcc -Isrc/qman.p -Isrc -I../src -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -DQMAN_GZIP=true -DQMAN_BZIP2=true -DQMAN_LZMA=true -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DWITH_GZFILEOP -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -MD -MQ src/qman.p/tui.c.o -MF src/qman.p/tui.c.o.d -o src/qman.p/tui.c.o -c ../src/tui.c
../src/tui.c: In function ‘init_tui’:
../src/tui.c:480:19: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
  480 |   signal(SIGUSR1, sigusr1_handler);
      |                   ^~~~~~~~~~~~~~~
      |                   |
      |                   void (*)(void)
In file included from ../src/lib.h:14,
                 from ../src/tui.c:3:
/usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void (*)(void)’
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
../src/tui.c:163:6: note: ‘sigusr1_handler’ declared here
  163 | void sigusr1_handler() {
      |      ^~~~~~~~~~~~~~~
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
```

The signal handler was declared without parameters, but signal(2) expects a function of type `void (*sighandler_t)(int)`.

https://web.archive.org/web/20250403212516/https://gcc.gnu.org/gcc-14/porting_to.html#incompatible-pointer-types

*Someone else is [trying to package qman](https://bugzilla.redhat.com/show_bug.cgi?id=2359302) for Fedora and apparently ran into this error