### PR TITLE
Adjust config and docs location based on installation prefix

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -4,7 +4,7 @@
 if get_option('config').enabled() or get_option('config').auto()
   install_data(
     ['qman.conf'],
-    install_dir: get_option('configdir'),
+    install_dir: get_option('prefix') + '/' + get_option('sysconfdir') + '/' + get_option('configdir'),
     install_tag: 'config'
   )
 endif
@@ -19,7 +19,7 @@ if get_option('config').enabled() or get_option('config').auto()
       'themes/adwaita-light.conf',
       'themes/catppuccin_latte.conf'
     ],
-    install_dir: get_option('configdir') + '/themes',
+    install_dir: get_option('prefix') + '/' + get_option('sysconfdir') + '/' + get_option('configdir') + '/themes',
     install_tag: 'config'
   )
 endif
@@ -28,7 +28,7 @@ endif
 if get_option('docs').enabled() or get_option('docs').auto()
   install_data(
     ['README.md'],
-    install_dir: get_option('docdir') + '/config',
+    install_dir: get_option('prefix') + '/' + get_option('docdir') + '/config',
     install_tag: 'doc'
   )
 endif

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -89,7 +89,7 @@ However, for some operating systems and Linux distros you may need to add
 extra directives to Qman's config file. See [OS_SPECIFIC.md](OS_SPECIFIC.md).
 
 The config file is located at `~/.config/qman/qman.conf` (user-specific) or
-`/etc/xdg/qman/qman.conf` (system-wide).
+`/usr/local/etc/xdg/qman/qman.conf` (system-wide, this value changes with the installation prefix).
 
 All configuration directives are documented in Qman's manual page:
 

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -12,7 +12,7 @@ if get_option('docs').enabled() or get_option('docs').auto()
       'TESTING.md',
       'TROUBLESHOOTING.md'
     ],
-    install_dir: get_option('docdir') + '/doc',
+    install_dir: get_option('prefix') + '/' + get_option('docdir') + '/doc',
     install_tag: 'doc'
   )
 endif

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,7 @@ subdir('doc')
 if get_option('docs').enabled() or get_option('docs').auto()
   install_data(
     ['README.md'],
-    install_dir: get_option('docdir'),
+    install_dir: get_option('prefix') + '/' + get_option('docdir'),
     install_tag: 'doc'
   )
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,7 +8,7 @@ option('docdir',
 
 option('configdir',
   type: 'string',
-  value: '/etc/xdg/qman',
+  value: 'xdg/qman',
   description: 'Where to install the configuration files'
 )
 

--- a/src/config.c.cog
+++ b/src/config.c.cog
@@ -746,6 +746,18 @@ void configure() {
       strlcpy(path, "/etc/qman/qman.conf", BS_LINE);
       fp = fopen(path, "r");
     }
+
+    // /usr/local/etc/xdg/qman/qman.conf
+    if (NULL == fp) {
+      strlcpy(path, "/usr/local/etc/xdg/qman/qman.conf", BS_LINE);
+      fp = fopen(path, "r");
+    }
+
+    // /usr/local/etc/qman/qman.conf
+    if (NULL == fp) {
+      strlcpy(path, "/usr/local/etc/qman/qman.conf", BS_LINE);
+      fp = fopen(path, "r");
+    }
   }
 
   // If we have a config file, process it


### PR DESCRIPTION
fixed from #55

When installing the global configuration, add the prefix to the configuration location.

This is useful when trying to install onto a mounted system (without using chroot or a package manager with a root option), as the config will now go to the correct place just by setting a prefix, and when packaging for systems like guix or nix, which have per-user, unprivileged installations and therefore doesn't have access to /etc/xdg.
