### PR TITLE
Add minimal-16 theme

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -17,7 +17,8 @@ if get_option('config').enabled() or get_option('config').auto()
       'themes/modernity-light.conf',
       'themes/adwaita.conf',
       'themes/adwaita-light.conf',
-      'themes/catppuccin_latte.conf'
+      'themes/catppuccin_latte.conf',
+      'themes/minimal-16.conf'
     ],
     install_dir: get_option('configdir') + '/themes',
     install_tag: 'config'

--- a/config/themes/minimal-16.conf
+++ b/config/themes/minimal-16.conf
@@ -1,0 +1,82 @@
+; minimal-16.conf
+; Qman theme
+; description: minimal theme using 16 colours, with optional unicode symbols
+; tags:        16color
+; TERM:        xterm-kitty
+; based on:    modernity from plp13
+; author:      denn-moe
+
+
+; If terminal emulator supports unicode, replace character with symbol
+[chars]
+
+;------------- status bar --------------
+
+trans_mode_name=  |            ;    
+trans_name_loc=   |            ;    
+
+;--------------- arrows ----------------
+
+arrow_up=         ^            ;  ⇡ ⌃ ⇧
+arrow_down=       v            ;  ⇣ ⌄ ⇩
+arrow_lr=         ~            ;  ⇄ ⇄ ⤄
+
+;------------- scroll bar --------------
+
+sbar_top=         +            ;  ▖ ┬ ▄
+sbar_vline=       |            ;  ▌ │ ▒
+sbar_block=       I            ;  ▌ ┃ █
+sbar_bottom=      +            ;  ▘ ┴ ▀
+
+;--------------- border ----------------
+
+box_hline=        -            ;  ─ ━ ═ ─
+box_vline=        |            ;  │ ┃ ║ │
+box_tl=           +            ;  ┌ ┏ ╔ ╭
+box_tr=           +            ;  ┐ ┓ ╗ ╮
+box_bl=           +            ;  └ ┗ ╚ ╰
+box_br=           +            ;  ┘ ┛ ╝ ╯
+
+
+;--------------- colours ---------------
+[colours]
+
+text=               15      0       false
+search=             10      0       true
+mark=               0       15      true
+link_man=           6       0       false
+link_man_f=         0       6       false
+link_http=          5       0       false
+link_http_f=        0       5       false
+link_email=         5       0       false
+link_email_f=       0       5       false
+link_file=          4       0       false
+link_file_f=        0       4       false
+link_ls=            11      0       false
+link_ls_f=          0       11      false
+sb_line=            7       0       true
+sb_block=           12      0       true
+stat_indic_mode=    0       12      true
+stat_indic_name=    15      8       false
+stat_indic_loc=     0       3       false
+stat_input_prompt=  15      0       false
+stat_input_help=    3       0       true
+stat_input_em=      1       0       true
+imm_border=         7       0       true
+imm_title=          0       12      true
+sp_input=           15      0       false
+sp_text=            8       0       false
+sp_text_f=          15      0       false
+help_text=          8       0       false
+help_text_f=        15      0       true
+history_text=       8       0       false
+history_text_f=     15      0       true
+toc_text=           8       0       false
+toc_text_f=         15      0       true
+
+
+;--------------- layout ----------------
+[layout]
+
+lmargin=            3
+rmargin=            3


### PR DESCRIPTION
created this minimal theme after learning a thing or two about terminal colors and the TERM variable and thought someone else might find it usefull.

this theme uses just the first 16 colours, which should play nicely with custom terminal themes.
this also solves the issue with the TERM variable.

between both screenshots i just changed the colours in kitty.conf.

onedark: 

<img width="1918" height="1051" alt="minima-16_onedark" src="https://github.com/user-attachments/assets/1751e157-9191-4f06-8288-398cbcb93c85" />

ayu-mirage:

<img width="1918" height="1051" alt="minima-16_ayu" src="https://github.com/user-attachments/assets/a00b42e8-808b-4d9f-98b5-15727f06ed5e" />


p.s. hope it's ok, that i added a few icons.