### PR TITLE
Updated OS Specific instructions for MacOS.

### DIFF
--- a/doc/OS_SPECIFIC.md
+++ b/doc/OS_SPECIFIC.md
@@ -121,8 +121,8 @@ Then, change the `[misc]` section of your config file as follows:
 [misc]
 system_type=darwin
 groff_path=/usr/local/bin/groff
-apropos=/usr/local/bin/fakeapropos.sh
-whatis=/usr/local/bin/fakewhatis.sh
+apropos_path=/usr/local/bin/fakeapropos.sh
+whatis_path=/usr/local/bin/fakewhatis.sh
 ```
 
 And, finally, run `mkfakewhatis.sh` as root:


### PR DESCRIPTION
Misc config options in the document example, `apropos` and `whatis` were missing `_path` in their name causing qman to fail to open and error with `Error in ~/.config/qman/qman.conf line 4: No such option 'apropos' in section 'misc'`.

I had to make this fix to get it work on mac. Updated the document with the correct option names.

Also, just started using this and love it!