### PR TITLE
Implement search in Table of Contents

### DIFF
--- a/src/program.h
+++ b/src/program.h
@@ -211,6 +211,12 @@ extern result_t *results;
 // Total number of search results in current page
 extern unsigned results_len;
 
+// Search results in the toc window
+extern result_t *toc_results;
+
+// Total number of search results in the toc window
+extern unsigned toc_results_len;
+
 // Marked text
 extern mark_t mark;
 
@@ -444,6 +450,9 @@ extern int search_next(result_t *res, unsigned res_len, unsigned from);
 // number `from`. If no such line exists, return -1. `res_len` is the length of
 // `res`.
 extern int search_prev(result_t *res, unsigned res_len, unsigned from);
+
+unsigned search_toc(result_t **dst, const wchar_t *needle, const toc_entry_t *toc,
+                unsigned toc_len, bool cs);
 
 // Extract from `lines` the text indicated by `mark`, and place it into `dst`,
 // allocating all needed memory. Return the length of `dst`. In case of error,


### PR DESCRIPTION
Hi :wave: I really like your project and was very excited to find out about it. There was one feature that was missing though to be exactly what I was looking for: a convenient way to navigate through search results (think like the `&` command in `less` or the `I` command in GNU `info`). Just searching for, e.g., "usb" in a man page as large as Qemu's and navigating through each result one at a time just wasn't going to cut it.

I decided to work with what was there already (i.e. the TOC) and get closer to my desired feature by adding a search functionality to it. It's basically a repurposed version of the already existing search functionality that uses the entries in the TOC to search and the `focus` variable to redraw the immediate window.

I don't normally write C code, and I think it shows (e.g. my error handling in C and my eye for memory leaks is quite mediocre or totally absent). I'm also not super familiar with the codebase, although I have to say, it was pretty easy to navigate, read, understand, and build, so I was able to quickly find out where I needed to make the minimum amount of changes to achieve search in TOC, so good job on the project.

I'm also convinced that there is a lot of overlap between TOC search and normal search, so there is a good chance for refactoring with an expert eye.

I'm opening this PR as a draft, in case you might be interested in the feature, and in case the changes need more polishing before being appropriate for merging.

Let me know what you think, looking forward to hearing from you!

Detailed changelog:

- Add `toc_search` and `toc_search_next` functions to `src/tui.c` to handle interactive search within the Table of Contents.
- Add `search_toc` to `src/program.c` to perform the search logic on TOC entries.
- Update `tui_toc` to handle `PA_SEARCH`, `PA_SEARCH_BACK`, `PA_SEARCH_NEXT`, and `PA_SEARCH_PREV` actions.
- Introduce `toc_results` and `toc_results_len` globals to store and manage TOC search results.